### PR TITLE
Exit code 1 in case of different files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.vscode

--- a/lib/jsdiff-cli.js
+++ b/lib/jsdiff-cli.js
@@ -35,4 +35,7 @@
     });
         
     console.log();
+    if (diff.length > 1) {
+        process.exit(1);
+    }
 })();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jsdiff-cli",
   "description": "JavaScript command line tool to get the difference in the files",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "https://github.com/kelsadita/jsdiff-cli",
   "author": {
     "name": "Kalpesh Adhatrao",


### PR DESCRIPTION
I'm using this in place of linux diff as a compatibility layer for windows in some tests, but it would be nice to have similar behaviour to the unix diff which exit with error code 1 in case the files are different.